### PR TITLE
Modified extconf to use shared snappy library if available.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,7 +1,12 @@
 require 'mkmf'
 require 'fileutils'
 
-unless have_library 'snappy_ext'
+if have_library 'snappy'
+  append_library $libs, 'snappy'
+elsif have_library 'snappy_ext'
+  append_library $libs, 'snappy_ext'
+else
+  # Download the snappy source code if the shared library is not available.
   dst = File.dirname File.expand_path __FILE__
 
   tar = 'tar'


### PR DESCRIPTION
I ran into an issue installing the snappy gem in our staging/production environments.  Due to firewall rules, the extconf script could not download the snappy-1.1.1 source from google code, which caused the native extensions to not compile.

The native snappy libraries are already installed on our servers and I modified extconf to pick those up if they're available.  I made sure the tests still pass on systems that do not have the native lib installed.  I haven't worked with native extensions much, so please let me know if you have any concerns.
