### PR TITLE
try pkg_config to locate libsnappy

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -6,7 +6,7 @@ def patch_autogen
   File.write('autogen.sh', File.read('autogen.sh').gsub(/libtoolize/, 'glibtoolize'))
 end
 
-unless have_library 'snappy'
+unless pkg_config('libsnappy') || have_library('snappy')
   # build vendor/snappy
   pwd = File.dirname File.expand_path __FILE__
   dir = File.join pwd, '..', 'vendor', 'snappy'


### PR DESCRIPTION
We have our own build of libsnappy in the /opt/ hierarchy, which we'd
like to use. By trying the pkg_config call first, the snappy gem can
pickup this location reliably.
