### PR TITLE
Make installation steps more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,27 @@ see https://github.com/google/snappy
 
 ## Preparation
 
-Use libsnappy
 
-    $ brew install snappy
+### macOS
 
-Or
+```bash
+$ brew install snappy
+$ brew install autoconf automake libtool
+```
 
-    $ brew install autoconf automake libtool
+### Ubuntu
+
+```bash
+$ apt-get install libsnappy-dev -y
+$ apt-get install libtool automake autoconf -y
+```
+
+### Alpine
+
+```bash
+$ apk install snappy
+$ apk install build-base libexecinfo automake autoconf libtool
+```
 
 ## Installation
 


### PR DESCRIPTION
Questions like #28 seem to arise from time to time. It took me a good 30 minutes to figure out which packages I need to install on Alpine to make snappy gem compile. I think there's an opportunity to make it easier for devs to find required dependencies.

cc @miyucy