### PR TITLE
snappy is ractor-safe

### DIFF
--- a/ext/api.c
+++ b/ext/api.c
@@ -91,6 +91,10 @@ snappy_valid_p(VALUE self, VALUE str)
 
 void Init_snappy_ext()
 {
+#if HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+
     VALUE rb_mSnappy;
     VALUE rb_mSnappy_singleton;
 

--- a/test/snappy_test.rb
+++ b/test/snappy_test.rb
@@ -76,4 +76,20 @@ class SnappyTest < Test::Unit::TestCase
       assert_false Snappy.valid?(d)
     end
   end
+
+  sub_test_case "Ractor safe" do
+    test "able to invoke non-main ractor" do
+      unless defined? ::Ractor
+        notify "Ractor not defined"
+        omit
+      end
+      s = random_data
+      a = Array.new(2) do
+        Ractor.new(s) do |s|
+          Snappy.inflate(Snappy.deflate(s)) == s
+        end
+      end
+      assert_equal [true, true], a.map(&:take)
+    end
+  end
 end


### PR DESCRIPTION
```ruby
# frozen_string_literal: true

$LOAD_PATH.prepend(__dir__ + "/lib")
require "snappy"

ractors = 4.times.map do
  Ractor.new do
    t = Time.now
    data = File.read("README.md")
    1000_000.times do
      deflated = Snappy.deflate(data)
      raise unless Snappy.inflate(deflated) == data
    end
    Time.now - t
  end
end
p ractors
sleep 0.5
p ractors
p ractors.map(&:take)
```

```bash
ruby -v test.rb 
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]
<internal:ractor>:267: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
[#<Ractor:#2 test.rb:7 blocking>, #<Ractor:#3 test.rb:7 running>, #<Ractor:#4 test.rb:7 running>, #<Ractor:#5 test.rb:7 running>]
[#<Ractor:#2 test.rb:7 running>, #<Ractor:#3 test.rb:7 running>, #<Ractor:#4 test.rb:7 running>, #<Ractor:#5 test.rb:7 running>]
[5.127062, 5.115264, 5.11657, 5.121178]
```
