### PR TITLE
Add necessary package in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ see https://github.com/google/snappy
 
 ```bash
 $ brew install snappy
-$ brew install autoconf automake libtool
+$ brew install autoconf automake cmake libtool
 ```
 
 ### Ubuntu


### PR DESCRIPTION
Hi! Thanks for your work in this gem.

When installing it on a Macbook Pro with M1 and macOS Monterey, I was banging my head against the wall for a while, and after installing `cmake` it magically worked. I saw that `cmake` was listed in a dependency after running `brew info snappy`, but for some reason it wasn't installed...

So, I wanted to share it with the community, in case it helps someone else.