### PR TITLE
Specify "snappy" using msys2_mingw_dependencies

### DIFF
--- a/snappy.gemspec
+++ b/snappy.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
     spec.add_dependency "snappy-jars", "~> 1.1.0"
   else
     spec.extensions = ["ext/extconf.rb"]
+    spec.metadata['msys2_mingw_dependencies'] = 'snappy'
   end
 end


### PR DESCRIPTION
On Windows (using [Windows Ruby Installer](https://rubyinstaller.org/)) the Snappy gem fails to install because it is missing the MSYS2 "snappy" package. There is an easy fix for this which can be done with `spec.metadata['msys2_mingw_dependencies'] = 'snappy'` in the gemfile.

The error on Windows is below:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: C:/ruby33/lib/ruby/gems/3.3.0/gems/snappy-0.3.0/ext
C:/ruby33/bin/ruby.exe extconf.rb
checking for pkg-config for libsnappy... not found
checking for -lsnappy... no
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```