### PR TITLE
fix: set cmake policy version minimum

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -13,7 +13,7 @@ unless have_libsnappy
     FileUtils.rm_rf "build"
     FileUtils.mkdir_p "build"
     Dir.chdir(File.join(dir, "build")) do
-      `cmake .. -DCMAKE_BUILD_TYPE=Release -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF`
+      `cmake .. -DCMAKE_BUILD_TYPE=Release -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
     end
   end
 


### PR DESCRIPTION
We're seeing these errors when building the gem locally with cmake 4:
```
CMake Error at CMakeLists.txt:29 (cmake_minimum_required):
 Compatibility with CMake < 3.5 has been removed from CMake.

 Update the VERSION argument <min> value. Or, use the <min>...<max> syntax
 to tell CMake that the project requires at least <min> but has been updated
 to work with policies introduced by <max> or earlier.

 Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

`-DCMAKE_POLICY_VERSION_MINIMUM=3.5` does indeed fix the local installations.